### PR TITLE
Update widget test generation to target video_feed_screen

### DIFF
--- a/mobile/test/infrastructure/mass_test_generation_test.dart
+++ b/mobile/test/infrastructure/mass_test_generation_test.dart
@@ -75,7 +75,7 @@ void main() {
           'run',
           'tools/generate_tests.dart',
           '--type=widget',
-          '--input=lib/screens/feed_screen_v2.dart'
+          '--input=lib/screens/video_feed_screen.dart'
         ],
         workingDirectory: Directory.current.path,
       );
@@ -86,7 +86,7 @@ void main() {
         reason: 'Widget test generation should succeed',
       );
 
-      final generatedTest = File('test/generated/feed_screen_v2_test.dart');
+      final generatedTest = File('test/generated/video_feed_screen_test.dart');
       expect(
         generatedTest.existsSync(),
         isTrue,


### PR DESCRIPTION
## Summary
- Updated the widget test generation script to use `video_feed_screen.dart` instead of `feed_screen_v2.dart` as the input source
- Adjusted the expected generated test file path accordingly

## Changes

### Test Infrastructure
- Modified the test command arguments in `mass_test_generation_test.dart` to point to `lib/screens/video_feed_screen.dart`
- Changed the expected generated test file from `test/generated/feed_screen_v2_test.dart` to `test/generated/video_feed_screen_test.dart`

## Test plan
- Run the updated test to ensure widget test generation succeeds for the new input file
- Verify the generated test file exists at the updated path and is correctly created

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e17831d5-fcec-4e1d-a6c4-2b4dbd746a79